### PR TITLE
fixed previous PR for team 4941

### DIFF
--- a/_frc/4900/4941.md
+++ b/_frc/4900/4941.md
@@ -9,9 +9,9 @@ team:
   sponsors:
     - Howard High School
   links:
-    Code: <a href="https://github.com/robobibb/">GitHub.com/RoboBibb</a>
-    Twitter: <a href="https://twitter.com/FRC4941">@FRC4941</a>
-    Facebook: <a href="https://www.facebook.com/teamrobobibb/">fb.com/teamrobobibb</a>
+    Code: https://github.com/robobibb/
+    Twitter: https://twitter.com/FRC4941
+    Facebook: https://fb.com/teamrobobibb/
 robot_code:
   2014 - 2015:
   - code not available

--- a/_frc/4900/4941.md
+++ b/_frc/4900/4941.md
@@ -9,6 +9,23 @@ team:
   sponsors:
     - Howard High School
   links:
-    Website: 
+    Code: <a href="https://github.com/robobibb/">GitHub.com/RoboBibb</a>
+    Twitter: <a href="https://twitter.com/FRC4941">@FRC4941</a>
+    Facebook: <a href="https://www.facebook.com/teamrobobibb/">fb.com/teamrobobibb</a>
+robot_code:
+  2014 - 2015:
+  - code not available
+  - labview
+  2016:
+  - https://github.com/robobibb/robot2016
+  - C++
+  2017:
+  - Main-Robot:
+    - https://github.com/robobibb/main-bot-2017
+    - C++
+  - Practice-Robot:
+    - https://github.com/robobibb/test-bot-2017
+    - C++
+    
 ---
-No content has been added for this team
+

--- a/_frc/4900/4941.md
+++ b/_frc/4900/4941.md
@@ -14,7 +14,7 @@ team:
     - Middle Georgia State University
     - Publix
   links:
-    GitHub  : https://github.com/robobibb/
+    Github  : https://github.com/robobibb/
     Twitter: https://twitter.com/FRC4941
     Facebook: https://fb.com/teamrobobibb/
 robot_code:

--- a/_frc/4900/4941.md
+++ b/_frc/4900/4941.md
@@ -10,7 +10,7 @@ team:
     - Howard High School
   links:
     Code: https://github.com/robobibb/
-    Twitter: https://twitter.com/FRC4941
+    Twitter(@FRC4941): https://twitter.com/FRC4941
     Facebook: https://fb.com/teamrobobibb/
 robot_code:
   2014 - 2015:

--- a/_frc/4900/4941.md
+++ b/_frc/4900/4941.md
@@ -7,15 +7,17 @@ team:
   rookie_year: 2014
   location: Macon, Georgia, USA
   sponsors:
-    - Howard High School
+    - Georgia Power
+    - Bestbuy
+    - NASA
+    - DoD STEM
+    - Middle Georgia State University
+    - Publix
   links:
-    Code: https://github.com/robobibb/
-    Twitter(@FRC4941): https://twitter.com/FRC4941
+    GitHub  : https://github.com/robobibb/
+    Twitter: https://twitter.com/FRC4941
     Facebook: https://fb.com/teamrobobibb/
 robot_code:
-  2014 - 2015:
-  - code not available
-  - labview
   2016:
   - https://github.com/robobibb/robot2016
   - C++
@@ -26,6 +28,5 @@ robot_code:
   - Practice-Robot:
     - https://github.com/robobibb/test-bot-2017
     - C++
-    
 ---
 


### PR DESCRIPTION
The links are no longer wrapped in <a> tags.
I think this is all I needed to change. If there's any other recommendations/requirements please tell me (I'll probably be updating this further after build season).